### PR TITLE
Set opcache.memory_consumption = 100

### DIFF
--- a/.docker/apache/7.0/00_opcache.ini
+++ b/.docker/apache/7.0/00_opcache.ini
@@ -3,6 +3,6 @@ opcache.enable = 1
 opcache.validate_timestamps = 1
 opcache.revalidate_freq = 2
 opcache.max_accelerated_files = 20000
-opcache.memory_consumption = 64
+opcache.memory_consumption = 100
 opcache.interned_strings_buffer = 16
 opcache.fast_shutdown = 1


### PR DESCRIPTION
We're hitting the default 64 MB limit pretty quickly, which is resulting in some files never getting cached.